### PR TITLE
SSH: Display subfolders when using dir & Skip public keys

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -451,7 +451,10 @@ class Main:
 				if os.path.isdir(self.args.key_file):
 					for dirname, dirnames, filenames in os.walk(self.args.key_file):
 						for keyfile in filenames:
-							keyfile_path = dirname + "/" + keyfile						
+							keyfile_path = dirname + "/" + keyfile
+							if keyfile.endswith('.pub',4):
+								self.logger.log_file("LOG-SSH: Skipping Public Key - %s" % keyfile_path)
+								continue					
 							pool.add_task(self.sshlogin, ip, port, self.args.username, keyfile_path, self.args.timeout)
 				else:
 					pool.add_task(self.sshlogin, ip, port, self.args.username, self.args.key_file, self.args.timeout)

--- a/lib/main.py
+++ b/lib/main.py
@@ -451,7 +451,7 @@ class Main:
 				if os.path.isdir(self.args.key_file):
 					for dirname, dirnames, filenames in os.walk(self.args.key_file):
 						for keyfile in filenames:
-							keyfile_path = self.args.key_file + "/" + keyfile						
+							keyfile_path = dirname + "/" + keyfile						
 							pool.add_task(self.sshlogin, ip, port, self.args.username, keyfile_path, self.args.timeout)
 				else:
 					pool.add_task(self.sshlogin, ip, port, self.args.username, self.args.key_file, self.args.timeout)


### PR DESCRIPTION
# Display Sub folders

### Before

```
root@kali:~# crowbar -b sshkey -s 10.11.1.44/32 -u root -k /root/test/ -p 22 -v
2016-01-12 11:41:19 START
2016-01-12 11:41:19 LOG-SSH: 10.11.1.44:22 - root:/root/test//hi13:2
2016-01-12 11:41:19 LOG-SSH: 10.11.1.44:22 - root:/root/test//hi1:2
2016-01-12 11:41:19 LOG-SSH: 10.11.1.44:22 - root:/root/test//hi:2
2016-01-12 11:41:19 LOG-SSH: 10.11.1.44:22 - root:/root/test//hi12:2
2016-01-12 11:41:21 STOP
No result is found ...
root@kali:~# 
```

### After

```
root@kali:~# crowbar -b sshkey -s 10.11.1.44/32 -u root -k /root/test/ -p 22 -v
2016-01-12 11:41:37 START
2016-01-12 11:41:37 LOG-SSH: 10.11.1.44:22 - root:/root/test/1/2/3/hi13:2
2016-01-12 11:41:37 LOG-SSH: 10.11.1.44:22 - root:/root/test/1/2/3/hi1:2
2016-01-12 11:41:37 LOG-SSH: 10.11.1.44:22 - root:/root/test/1/2/3/hi:2
2016-01-12 11:41:37 LOG-SSH: 10.11.1.44:22 - root:/root/test/1/2/3/hi12:2
2016-01-12 11:41:41 STOP
No result is found ...
root@kali:~# 