### PR TITLE
OpenVPN Log Format Change (Thx @dextacy10-13)

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -181,11 +181,11 @@ class Main:
             self.openvpn_path, self.args.config, brute_file_name, host, port)
         proc = subprocess.Popen(shlex.split(openvpn_cmd), shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-        brute = "LOG-OPENVPN: " + host + ":" + username + " - " + password + ":" + brute_file_name
+        brute = "LOG-OPENVPN: " + host + ":" + port + " - " + username + ":" + password + " - " + brute_file_name
         self.logger.log_file(brute)
         for line in iter(proc.stdout.readline, ''):
             if re.search(self.vpn_success, line):
-                result = bcolors.OKGREEN + "OPENVPN-SUCCESS: " + bcolors.ENDC + bcolors.OKBLUE + host + " - " + username + ":" + password + bcolors.ENDC
+                result = bcolors.OKGREEN + "OPENVPN-SUCCESS: " + bcolors.ENDC + bcolors.OKBLUE + host + ":" + port + " - " + username + ":" + password + bcolors.ENDC
                 self.logger.output_file(result)
                 Main.is_success = 1
                 os.kill(proc.pid, signal.SIGQUIT)


### PR DESCRIPTION
Source: https://github.com/dextacy10-13/crowbar/commit/bf7966c6f7fcdc2ad80348083575b3e9a1b99ebc
OpenVPN Log Format Change -  Add port number to the log entry and group username and password together as opposed to IP and username.
e.g.

Before
2015-09-08 21:34:02 LOG-OPENVPN: 192.168.101.5:den - diana:/tmp/tmp5Fp6Ov

Now
2015-09-08 21:34:02 LOG-OPENVPN: 192.168.101.5:443 - den:diana - /tmp/tmp5Fp6Ov