### PR TITLE
Added support for IP addresses which are not in CIDR notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ _Don't forget to patch `./lib/main.py` to point to the new binary_!
 - **-o**: `</path/to/file>` to store the successfully attempt(s) (default is `./crowbar.out`)
 - **-p**: Port number (if the service is not on the default port)
 - **-q**: Enable quiet mode (only show successful logins)
-- **-s**: Target IP address/range (in CIDR notation)
-- **-S**: `</path/to/file>` which is stores target IP addresses
+- **-s**: Target IP address/range
+- **-S**: `</path/to/file>` File containing target IP addresses/ranges
 - **-t**: Timeout value
 - **-u**: Single username
 - **-U**: `</path/to/file>` which stores the username list

--- a/lib/core/common.py
+++ b/lib/core/common.py
@@ -1,9 +1,11 @@
 class bcolors:
     OKBLUE = '\033[94m'
     OKGREEN = '\033[92m'
+    FAIL = '\033[91m'
     ENDC = '\033[0m'
 
     def disable(self):
         self.OKBLUE = ''
         self.OKGREEN = ''
+        self.FAIL = ''
         self.ENDC = ''

--- a/lib/core/iprange.py
+++ b/lib/core/iprange.py
@@ -30,6 +30,10 @@ class IpRange:
         return socket.inet_ntoa(struct.pack('!I', ipbinary))
 
     def iprange(self, ipaddr):
+        single_re = re.compile(r"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$", re.VERBOSE) # IP address without CIDR notation
+        res = single_re.match(ipaddr)
+        if res:
+            return [ipaddr.strip()]
         span_re = re.compile(r'''(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})   # The beginning IP address
                              \s*-\s*
                              (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})       # The end IP address

--- a/lib/main.py
+++ b/lib/main.py
@@ -183,7 +183,7 @@ class Main:
                 mess = "File: %s cannot be opened" % os.path.abspath(self.args.server_file)
                 raise CrowbarExceptions(mess)
             except:
-                mess = "Invalid IP Address! Please use IP/CIDR notation <192.168.37.37/32, 192.168.1.0/24>"
+                mess = "Invalid IP Address! " + bcolors.FAIL + str(_) + bcolors.ENDC + "Please use valid IP/CIDR notation <192.168.43.56, 192.168.37.37/32, 192.168.1.0/24>"
                 raise CrowbarExceptions(mess)
 
         if self.args.verbose:


### PR DESCRIPTION
Hi, thanks for the tool.

Added support for IP addresses which are not in CIDR notation.
Works well with -S and -s
e.g:
```
# ./crowbar.py -b rdp -s 192.168.2.182 -u admin -c Aa123456
# ./crowbar.py -b rdp -S fileContainingIPaddressesAndRanges.txt -u admin -c Aa123456
```