### PR TITLE
Fix undefined names: Don’t forget 'self’ when calling methods

### DIFF
--- a/lib/core/iprange.py
+++ b/lib/core/iprange.py
@@ -38,7 +38,7 @@ class IpRange:
         if res:
             beginning = res.group(1)
             end = res.group(2)
-            return span_iprange(beginning, end)
+            return self.span_iprange(beginning, end)
 
         cidr_re = re.compile(r'''(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})   # The IP address
                              /(\d{1,2})                                 # The mask
@@ -55,15 +55,15 @@ class IpRange:
                           ''', re.VERBOSE)
         res = wild_re.match(ipaddr)
         if res:
-            return wildcard_iprange(ipaddr)
+            return self.wildcard_iprange(ipaddr)
 
         raise InvalidIPAddress
 
     def span_iprange(self, beginning, end):
         b = self.ipaddr_to_binary(beginning)
-        e = ipaddr_to_binary(end)
+        e = self.ipaddr_to_binary(end)
         while (b <= e):
-            yield binary_to_ipaddr(b)
+            yield self.binary_to_ipaddr(b)
             b = b + 1
 
     def cidr_iprange(self, ipaddr, cidrmask):


### PR DESCRIPTION
Fix ___undefined names___: Don’t forget 'self’ when calling methods.

$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./lib/nmap.py:46:18: F821 undefined name 'nmap'
            nm = nmap.PortScanner()
                 ^
./lib/core/iprange.py:41:20: F821 undefined name 'span_iprange'
            return span_iprange(beginning, end)
                   ^
./lib/core/iprange.py:58:20: F821 undefined name 'wildcard_iprange'
            return wildcard_iprange(ipaddr)
                   ^
./lib/core/iprange.py:64:13: F821 undefined name 'ipaddr_to_binary'
        e = ipaddr_to_binary(end)
            ^
./lib/core/iprange.py:66:19: F821 undefined name 'binary_to_ipaddr'
            yield binary_to_ipaddr(b)
                  ^
5     F821 undefined name 'span_iprange'
5
```